### PR TITLE
Share functionality added

### DIFF
--- a/Reacture/Reacture/RCT_EditViewController.swift
+++ b/Reacture/Reacture/RCT_EditViewController.swift
@@ -91,8 +91,12 @@ class RCT_EditViewController: UIViewController {
 
     @IBAction func shareButtonTapped(sender: AnyObject) {
         print("Share Button Tapped")
+        let shareTextRCTImage = "Shared with #reacture"
+        let shareImageRCTImage: UIImage = UIImage(named: "mock_selfie")!
+        let shareViewController: UIActivityViewController = UIActivityViewController(activityItems: [(shareImageRCTImage), shareTextRCTImage], applicationActivities: nil)
+        self.presentViewController(shareViewController, animated: true, completion: nil)
     }
-
+    
     @IBAction func layoutButtonTapped(sender: AnyObject) {
         print("Layout Button Tapped")
         //animateContainerView()


### PR DESCRIPTION
Tested on live iPhone. Works with all social media, mail, messages, etc.

```
@IBAction func shareButtonTapped(sender: AnyObject) {
    print("Share Button Tapped")
    let shareTextRCTImage = "Shared with #reacture"
    let shareImageRCTImage: UIImage = UIImage(named: "mock_selfie")!
    let shareViewController: UIActivityViewController = UIActivityViewController(activityItems: [(shareImageRCTImage), shareTextRCTImage], applicationActivities: nil)
    self.presentViewController(shareViewController, animated: true, completion: nil)
}
```
